### PR TITLE
Correct description of second group of holidays

### DIFF
--- a/fr_FR.UTF-8/calendar.jferies
+++ b/fr_FR.UTF-8/calendar.jferies
@@ -16,7 +16,7 @@ LANG=fr_FR.UTF-8
 07/14	Fête nationale française
 11/11	Armistice 1918
 
-/* Jours fériés religieux */
+/* Jours fériés issus du christianisme */
 Easter		Pâques
 Easter+1 	Lundi de Pâques
 Easter+39	Ascension


### PR DESCRIPTION
Translation for reviewers and committers:
- Original says "religious holidays"
- Change says "holidays stemming from Christianity"