### PR TITLE
Updating calendar.holiday and a correction

### DIFF
--- a/calendar.holiday
+++ b/calendar.holiday
@@ -297,6 +297,7 @@
 07/25	National Rebellion Day (3 days) in Cuba
 07/25	Republic Day in Tunisia
 07/25	St. James, Patron Saint in Spain
+07/25   Founding of Guayaquil in Ecuador
 07/26	Independence Day in Liberia
 07/26	National Day in Maldives
 07/27	Barbosa's Birthday (celebrated in Puerto Rico)
@@ -307,7 +308,6 @@
 07/MonThird	Day of Sea in Japan
 08/01	Discovery Day in Trinidad and Tobago
 08/01	Emancipation Day in Granada
-08/01	Founding of Asuncion in Paraguay
 08/01	Freedom Day in Guyana
 08/01	National Day in Switzerland
 08/01	National Holidays (5 days) in El Salvador
@@ -333,7 +333,7 @@
 08/14	Independence Day in Pakistan
 08/14	Waddi Dhahab in Morocco
 08/15	VJ Day, 1945
-08/15	Founding of Ascuncion in Paraguay
+08/15	Founding of Asuncion in Paraguay
 08/15	Independence Day in India
 08/15	Liberation Day in South Korea
 08/15	National Day in Congo
@@ -522,6 +522,7 @@
 12/03	National Holiday in Laos
 12/05	King's Birthday in Thailand
 12/06	Independence Day in Finland
+12/06   Founding of Quito in Ecuador
 12/07	Delaware Day in Delaware
 12/07	Independence Day in Ivory Coast
 12/07	Independence Day in Panama


### PR DESCRIPTION
Adding holidays of foundations of Guayaquil and Quito, in Ecuador.

Additionally, the Founding of Asuncion in Paraguay is 08/15, not 08/01.