### PR TITLE
Fix two typos in calendar files

### DIFF
--- a/calendar.birthday
+++ b/calendar.birthday
@@ -345,6 +345,6 @@
 12/25	Isaac Newton (Sir) born in Grantham, England, 1642
 12/26	Chas. Babbage born, 1791
 12/28	John von Neumann born, 1903
-12/29	Grigori Yefimovich Rasputin assasinated, 1916
+12/29	Grigori Yefimovich Rasputin assassinated, 1916
 
 #endif /* !_calendar_birthday_ */

--- a/calendar.history
+++ b/calendar.history
@@ -110,7 +110,7 @@
 02/20	John Glenn orbits the Earth 3 times, 1962
 02/21	Battle of Verdun begins, 1916 1M casualties
 02/21	First telephone directory, New Haven, Connecticut, 1878
-02/21	Malcom X shot to death in Harlem, 1965
+02/21	Malcolm X shot to death in Harlem, 1965
 02/22	Start of the Czechoslovak Revolution, 1948
 02/23	Lt. Calley confesses his role in the Mỹ Lai massacre, implicates
 	Cpt. Medina, 1971


### PR DESCRIPTION
- s/assasinated/assassinated/
- s/Malcom/Malcolm/

Obtained from:    DragonflyBSD